### PR TITLE
Feat/#19 vendor create get

### DIFF
--- a/vendor/build.gradle
+++ b/vendor/build.gradle
@@ -13,6 +13,13 @@ java {
 	}
 }
 
+jar {
+	enabled = false
+}
+bootJar {
+	enabled = true
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -25,9 +32,16 @@ repositories {
 
 ext {
 	set('springCloudVersion', "2023.0.3")
+	set('querydslVersion', "5.0.0")
 }
 
 dependencies {
+	// QueryDSL
+	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
@@ -38,7 +38,7 @@ public class VendorController {
     }
 
     /** 업체 단건 조회 api */
-    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGER, MASTER) 추가
+    // TODO: 사용자 인증 추가
     @GetMapping("/{vendorId}")
     public ResponseEntity<? extends CommonResponse> getVendor(@PathVariable UUID vendorId) {
         return ResponseEntity.status(GET_VENDOR_SUCCESS.getHttpStatus())
@@ -46,7 +46,7 @@ public class VendorController {
     }
 
     /** 업체 검색 api */
-    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGER, MASTER) 추가
+    // TODO: 사용자 인증 추가
     @GetMapping("")
     @PageSizeLimit
     public ResponseEntity<? extends CommonResponse> searchVendors(

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
@@ -6,6 +6,7 @@ import static com.yongyonglee.vendor.global.response.SuccessResponse.success;
 
 import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.service.VendorService;
+import com.yongyonglee.vendor.global.aop.page.PageSizeLimit;
 import com.yongyonglee.vendor.global.response.CommonResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,7 @@ public class VendorController {
     /** 업체 검색 api */
     // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGER, MASTER) 추가
     @GetMapping("")
+    @PageSizeLimit
     public ResponseEntity<? extends CommonResponse> searchVendors(
             @RequestParam(required = false) String vendorName,
             @RequestParam(required = false) String vendorCategory,

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
@@ -1,0 +1,30 @@
+package com.yongyonglee.vendor.domain.vendor.controller;
+
+import static com.yongyonglee.vendor.domain.vendor.message.SuccessMessage.CREATE_VENDOR_SUCCESS;
+import static com.yongyonglee.vendor.global.response.SuccessResponse.success;
+
+import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
+import com.yongyonglee.vendor.domain.vendor.service.VendorService;
+import com.yongyonglee.vendor.global.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/vendors")
+@RequiredArgsConstructor
+public class VendorController {
+
+    private final VendorService vendorService;
+
+    /** 업체 생성 api */
+    // TODO: 사용자 인증 및 인가(MASTER) 추가
+    @PostMapping("")
+    public ResponseEntity<? extends CommonResponse> createVendor(@RequestBody CreateVendorRequestDto requestDto) {
+        return ResponseEntity.status(CREATE_VENDOR_SUCCESS.getHttpStatus())
+                .body(success(CREATE_VENDOR_SUCCESS.getMessage(), vendorService.createVendor(requestDto)));
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
@@ -1,13 +1,17 @@
 package com.yongyonglee.vendor.domain.vendor.controller;
 
 import static com.yongyonglee.vendor.domain.vendor.message.SuccessMessage.CREATE_VENDOR_SUCCESS;
+import static com.yongyonglee.vendor.domain.vendor.message.SuccessMessage.GET_VENDOR_SUCCESS;
 import static com.yongyonglee.vendor.global.response.SuccessResponse.success;
 
 import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.service.VendorService;
 import com.yongyonglee.vendor.global.response.CommonResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +30,13 @@ public class VendorController {
     public ResponseEntity<? extends CommonResponse> createVendor(@RequestBody CreateVendorRequestDto requestDto) {
         return ResponseEntity.status(CREATE_VENDOR_SUCCESS.getHttpStatus())
                 .body(success(CREATE_VENDOR_SUCCESS.getMessage(), vendorService.createVendor(requestDto)));
+    }
+
+    /** 업체 단건 조회 api */
+    // TODO: 사용자 인증 추가
+    @GetMapping("/{vendorId}")
+    public ResponseEntity<? extends CommonResponse> getVendor(@PathVariable UUID vendorId) {
+        return ResponseEntity.status(GET_VENDOR_SUCCESS.getHttpStatus())
+                .body(success(GET_VENDOR_SUCCESS.getMessage(), vendorService.getVendor(vendorId)));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/controller/VendorController.java
@@ -9,12 +9,16 @@ import com.yongyonglee.vendor.domain.vendor.service.VendorService;
 import com.yongyonglee.vendor.global.response.CommonResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,10 +37,23 @@ public class VendorController {
     }
 
     /** 업체 단건 조회 api */
-    // TODO: 사용자 인증 추가
+    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGER, MASTER) 추가
     @GetMapping("/{vendorId}")
     public ResponseEntity<? extends CommonResponse> getVendor(@PathVariable UUID vendorId) {
         return ResponseEntity.status(GET_VENDOR_SUCCESS.getHttpStatus())
                 .body(success(GET_VENDOR_SUCCESS.getMessage(), vendorService.getVendor(vendorId)));
+    }
+
+    /** 업체 검색 api */
+    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGER, MASTER) 추가
+    @GetMapping("")
+    public ResponseEntity<? extends CommonResponse> searchVendors(
+            @RequestParam(required = false) String vendorName,
+            @RequestParam(required = false) String vendorCategory,
+            @RequestParam(required = false) UUID hubId,
+            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.status(GET_VENDOR_SUCCESS.getHttpStatus())
+                .body(success(GET_VENDOR_SUCCESS.getMessage(), vendorService.searchVendors(vendorName, vendorCategory, hubId, pageable)));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/dto/request/CreateVendorRequestDto.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/dto/request/CreateVendorRequestDto.java
@@ -1,0 +1,12 @@
+package com.yongyonglee.vendor.domain.vendor.dto.request;
+
+import java.util.UUID;
+
+public record CreateVendorRequestDto (
+        UUID hubId,
+        String vendorName,
+        String vendorCategory,
+        String vendorAddress
+) {
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/dto/response/VendorResponseDto.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/dto/response/VendorResponseDto.java
@@ -1,0 +1,29 @@
+package com.yongyonglee.vendor.domain.vendor.dto.response;
+
+import com.yongyonglee.vendor.domain.vendor.model.Vendor;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record VendorResponseDto(
+        UUID vendorId,
+        String vendorName,
+        String vendorCategory,
+        String vendorAddress,
+        UUID hubId,
+        LocalDateTime createdAt
+){
+
+    public static VendorResponseDto from (Vendor vendor) {
+        return VendorResponseDto.builder()
+                .vendorId(vendor.getId())
+                .vendorName(vendor.getVendorName())
+                .vendorCategory(vendor.getVendorCategory().getCategory())
+                .vendorAddress(vendor.getVendorAddress())
+                .hubId(vendor.getHubId())
+                .createdAt(vendor.getCreatedAt())
+                .build();
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/exception/VendorException.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/exception/VendorException.java
@@ -1,0 +1,22 @@
+package com.yongyonglee.vendor.domain.vendor.exception;
+
+import com.yongyonglee.vendor.domain.vendor.message.ExceptionMessage;
+import org.springframework.http.HttpStatus;
+
+public class VendorException extends RuntimeException {
+
+    private final ExceptionMessage exceptionMessage;
+
+    public VendorException(ExceptionMessage exceptionMessage) {
+        super("[Vendor Exception] : " + exceptionMessage.getMessage());
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return exceptionMessage.getHttpStatus();
+    }
+
+    public String getMessage() {
+        return exceptionMessage.getMessage();
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/message/ExceptionMessage.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/message/ExceptionMessage.java
@@ -1,0 +1,19 @@
+package com.yongyonglee.vendor.domain.vendor.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+
+    VENDOR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 업체를 찾을 수 없습니다."),
+    VENDOR_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "업체에 대한 접근 권한이 없습니다."),
+
+    VENDOR_CATEGORY_INVALID(HttpStatus.NOT_FOUND, "올바르지 않은 업체 타입입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/message/SuccessMessage.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/message/SuccessMessage.java
@@ -1,0 +1,20 @@
+package com.yongyonglee.vendor.domain.vendor.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessMessage {
+
+    CREATE_VENDOR_SUCCESS(HttpStatus.CREATED, "업체 생성을 성공했습니다"),
+    GET_VENDOR_SUCCESS(HttpStatus.OK, "업체 조회를 성공했습니다"),
+    SEARCH_VENDOR_SUCCESS(HttpStatus.OK, "업체 검색을 성공했습니다"),
+    UPDATE_VENDOR_SUCCESS(HttpStatus.OK, "업체 수정을 성공했습니다"),
+    DELETE_VENDOR_SUCCESS(HttpStatus.OK, "업체 삭제를 성공했습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/model/Vendor.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/model/Vendor.java
@@ -1,5 +1,6 @@
 package com.yongyonglee.vendor.domain.vendor.model;
 
+import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.model.constant.VendorCategory;
 import com.yongyonglee.vendor.global.entity.TimeBase;
 import jakarta.persistence.Column;
@@ -12,6 +13,7 @@ import jakarta.persistence.Id;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,5 +42,26 @@ public class Vendor extends TimeBase {
 
     @Column(name = "vendor_address", nullable = false, columnDefinition = "VARCHAR(100)")
     private String vendorAddress;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public Vendor(Long userId, UUID hubId, String vendorName, VendorCategory vendorCategory,
+            String vendorAddress) {
+        this.userId = userId;
+        this.hubId = hubId;
+        this.vendorName = vendorName;
+        this.vendorCategory = vendorCategory;
+        this.vendorAddress = vendorAddress;
+    }
+
+    public static Vendor from(Long userId, VendorCategory vendorCategory, CreateVendorRequestDto requestDto) {
+
+        return Vendor.builder()
+                .userId(userId)
+                .hubId(requestDto.hubId())
+                .vendorName(requestDto.vendorName())
+                .vendorAddress(requestDto.vendorAddress())
+                .vendorCategory(vendorCategory)
+                .build();
+    }
 
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/model/constant/VendorCategory.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/model/constant/VendorCategory.java
@@ -1,5 +1,8 @@
 package com.yongyonglee.vendor.domain.vendor.model.constant;
 
+import com.yongyonglee.vendor.domain.vendor.exception.VendorException;
+import com.yongyonglee.vendor.domain.vendor.message.ExceptionMessage;
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +15,11 @@ public enum VendorCategory {
 
     private final String category;
 
+    public static VendorCategory findByCategory(String category) {
+
+        return Arrays.stream(VendorCategory.values())
+                .filter(v -> v.getCategory().equals(category))
+                .findFirst()
+                .orElseThrow(() -> new VendorException(ExceptionMessage.VENDOR_CATEGORY_INVALID));
+    }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/repository/VendorRepository.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/repository/VendorRepository.java
@@ -1,6 +1,7 @@
 package com.yongyonglee.vendor.domain.vendor.repository;
 
 import com.yongyonglee.vendor.domain.vendor.model.Vendor;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface VendorRepository extends JpaRepository<Vendor, UUID> {
 
+    Optional<Vendor> findByIdAndIsDeletedFalse(UUID vendorId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/repository/VendorRepository.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/repository/VendorRepository.java
@@ -4,10 +4,12 @@ import com.yongyonglee.vendor.domain.vendor.model.Vendor;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface VendorRepository extends JpaRepository<Vendor, UUID> {
+public interface VendorRepository extends JpaRepository<Vendor, UUID>,
+        QuerydslPredicateExecutor<Vendor> {
 
     Optional<Vendor> findByIdAndIsDeletedFalse(UUID vendorId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/repository/VendorRepository.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/repository/VendorRepository.java
@@ -1,0 +1,11 @@
+package com.yongyonglee.vendor.domain.vendor.repository;
+
+import com.yongyonglee.vendor.domain.vendor.model.Vendor;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VendorRepository extends JpaRepository<Vendor, UUID> {
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
@@ -1,0 +1,9 @@
+package com.yongyonglee.vendor.domain.vendor.service;
+
+import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
+import com.yongyonglee.vendor.domain.vendor.dto.response.VendorResponseDto;
+
+public interface VendorService {
+
+    VendorResponseDto createVendor(CreateVendorRequestDto requestDto);
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
@@ -2,8 +2,11 @@ package com.yongyonglee.vendor.domain.vendor.service;
 
 import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.dto.response.VendorResponseDto;
+import java.util.UUID;
 
 public interface VendorService {
 
     VendorResponseDto createVendor(CreateVendorRequestDto requestDto);
+
+    VendorResponseDto getVendor(UUID vendorId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
@@ -3,10 +3,14 @@ package com.yongyonglee.vendor.domain.vendor.service;
 import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.dto.response.VendorResponseDto;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface VendorService {
 
     VendorResponseDto createVendor(CreateVendorRequestDto requestDto);
 
     VendorResponseDto getVendor(UUID vendorId);
+
+    Page<VendorResponseDto> searchVendors(String vendorName, String vendorCategory, UUID hubId, Pageable pageable);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
@@ -21,6 +21,7 @@ public class VendorServiceImpl implements VendorService {
 
         VendorCategory vendorCategory = VendorCategory.findByCategory(requestDto.vendorCategory());
 
+        // TODO: userId 가져오는 부분과 HubId 유효성 검사 로직 추가하기
         Vendor vendor = vendorRepository.save(Vendor.from(1L, vendorCategory, requestDto));
 
         return VendorResponseDto.from(vendor);

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
@@ -1,0 +1,28 @@
+package com.yongyonglee.vendor.domain.vendor.service;
+
+import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
+import com.yongyonglee.vendor.domain.vendor.dto.response.VendorResponseDto;
+import com.yongyonglee.vendor.domain.vendor.model.Vendor;
+import com.yongyonglee.vendor.domain.vendor.model.constant.VendorCategory;
+import com.yongyonglee.vendor.domain.vendor.repository.VendorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class VendorServiceImpl implements VendorService {
+
+    private final VendorRepository vendorRepository;
+
+    @Override
+    public VendorResponseDto createVendor(CreateVendorRequestDto requestDto) {
+
+        VendorCategory vendorCategory = VendorCategory.findByCategory(requestDto.vendorCategory());
+
+        Vendor vendor = vendorRepository.save(Vendor.from(1L, vendorCategory, requestDto));
+
+        return VendorResponseDto.from(vendor);
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
@@ -2,9 +2,12 @@ package com.yongyonglee.vendor.domain.vendor.service;
 
 import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.dto.response.VendorResponseDto;
+import com.yongyonglee.vendor.domain.vendor.exception.VendorException;
+import com.yongyonglee.vendor.domain.vendor.message.ExceptionMessage;
 import com.yongyonglee.vendor.domain.vendor.model.Vendor;
 import com.yongyonglee.vendor.domain.vendor.model.constant.VendorCategory;
 import com.yongyonglee.vendor.domain.vendor.repository.VendorRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,5 +28,18 @@ public class VendorServiceImpl implements VendorService {
         Vendor vendor = vendorRepository.save(Vendor.from(1L, vendorCategory, requestDto));
 
         return VendorResponseDto.from(vendor);
+    }
+
+    @Override
+    public VendorResponseDto getVendor(UUID vendorId) {
+
+        Vendor vendor = findById(vendorId);
+
+        return VendorResponseDto.from(vendor);
+    }
+
+    public Vendor findById(UUID vendorId) {
+        return vendorRepository.findByIdAndIsDeletedFalse(vendorId)
+                .orElseThrow(() -> new VendorException(ExceptionMessage.VENDOR_NOT_FOUND));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/aop/page/PageSizeAspect.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/aop/page/PageSizeAspect.java
@@ -1,0 +1,36 @@
+package com.yongyonglee.vendor.global.aop.page;
+
+import java.util.Set;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class PageSizeAspect {
+
+    private static final Set<Integer> VALID_SIZES = Set.of(10, 30, 50);
+    private static final int DEFAULT_SIZE = 10;
+
+    @Around("@annotation(PageSizeLimit)")
+    public Object checkPageSize(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < args.length; i++) {
+            if (args[i] instanceof Pageable) {
+                Pageable pageable = (Pageable) args[i];
+                int pageSize = pageable.getPageSize();
+
+                if (!VALID_SIZES.contains(pageSize)) {
+                    args[i] = PageRequest.of(pageable.getPageNumber(), DEFAULT_SIZE, pageable.getSort());
+                }
+            }
+        }
+
+        return joinPoint.proceed(args);
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/aop/page/PageSizeLimit.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/aop/page/PageSizeLimit.java
@@ -1,0 +1,12 @@
+package com.yongyonglee.vendor.global.aop.page;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PageSizeLimit {
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/config/WebSecurityConfig.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/config/WebSecurityConfig.java
@@ -1,0 +1,65 @@
+package com.yongyonglee.vendor.global.config;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf((csrf) -> csrf.disable());
+
+        // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+        http.sessionManagement(
+                (sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(
+                (authorizeHttpRequests) ->
+                        authorizeHttpRequests
+                                .requestMatchers(
+                                        PathRequest.toStaticResources().atCommonLocations())
+                                .permitAll() // resources 접근 허용 설정
+                                .requestMatchers("/**").permitAll()
+                                .anyRequest()
+                                .authenticated() // 그 외 모든 요청 인증처리
+        );
+
+        http.cors(withDefaults());
+
+        // 필터 관리
+        //http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    // CORS 설정을 위한 Bean 추가
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("*"); // 모든 origin 허용
+        configuration.addAllowedMethod("*");        // 모든 HTTP 메서드 허용
+        configuration.setAllowCredentials(true);
+        configuration.addAllowedHeader("*");        // 모든 헤더 허용
+
+        configuration.addExposedHeader("Authorization");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 CORS 설정 적용
+
+        return source;
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/exception/GlobalExceptionHandler.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.yongyonglee.vendor.global.exception;
+
+import static com.yongyonglee.vendor.global.response.ExceptionResponse.of;
+
+import com.yongyonglee.vendor.domain.vendor.exception.VendorException;
+import com.yongyonglee.vendor.global.response.ExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(VendorException.class)
+    public ResponseEntity<ExceptionResponse> handleVendorException(VendorException e) {
+        return ResponseEntity.status(e.getHttpStatus()).body(of(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(Exception e) {
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(of(e.getLocalizedMessage()));
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/response/CommonResponse.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/response/CommonResponse.java
@@ -1,0 +1,11 @@
+package com.yongyonglee.vendor.global.response;
+
+import lombok.NonNull;
+
+public interface CommonResponse {
+
+//    boolean success();
+
+    @NonNull
+    String message();
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/response/ExceptionResponse.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/response/ExceptionResponse.java
@@ -1,0 +1,20 @@
+package com.yongyonglee.vendor.global.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(access = PRIVATE)
+public record ExceptionResponse(
+//        boolean success,
+        @NonNull
+        String message
+) implements CommonResponse {
+
+    public static ExceptionResponse of(String message) {
+        return ExceptionResponse.builder()
+                .message(message)
+                .build();
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/response/SuccessResponse.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/response/SuccessResponse.java
@@ -1,0 +1,28 @@
+package com.yongyonglee.vendor.global.response;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(access = PRIVATE)
+public record SuccessResponse<T> (
+//        boolean success,
+        @NonNull
+        String message,
+        @JsonInclude(value = NON_NULL) T data
+) implements CommonResponse {
+
+    public static <T> SuccessResponse<T> success(String message, T data) {
+        return SuccessResponse.<T>builder()
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static SuccessResponse<?> success(String message) {
+        return SuccessResponse.builder().message(message).build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#19 

## 📝작업 내용
- 업체 생성 POST `/api/v1/vendors`
- 업체 단건 조회 GET `/api/v1/vendors/{vendorId}`
- 업체 조회(검색) GET `/api/v1/vendors?vendorName&vendorCategory&hubId&page&size`

## 💬리뷰 요구사항(선택)
- vendor 목록을 조회 및 검색하는 기능에서 현재 api 명세서에는 
  - 업체 검색
  - 업체 전체 조회
  - 허브별 업체 조회

가 모두 다르게 있는데, 제가 구현한 업체 조회(검색)와 같이 하면 
위의 3개의 api를 분리하지 않아도 모두 동작할 수 있을 것 같습니다.