### PR TITLE
Feat/#29 product crud

### DIFF
--- a/vendor/build.gradle
+++ b/vendor/build.gradle
@@ -36,6 +36,9 @@ ext {
 }
 
 dependencies {
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	// QueryDSL
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.yongyonglee.vendor.domain.product.controller;
 
 import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.CREATE_PRODUCT_SUCCESS;
+import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.DELETE_PRODUCT_SUCCESS;
 import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.GET_PRODUCT_SUCCESS;
 import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.UPDATE_PRODUCT_SUCCESS;
 import static com.yongyonglee.vendor.global.response.SuccessResponse.success;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -72,5 +74,16 @@ public class ProductController {
 
         return ResponseEntity.status(UPDATE_PRODUCT_SUCCESS.getHttpStatus())
                 .body(success(UPDATE_PRODUCT_SUCCESS.getMessage(), productService.updateProductQuantity(productId, requestDto)));
+    }
+
+    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGE, MASTER) 추가
+    @Operation(summary = "상품 삭제", description = "상품을 삭제할 때 사용하는 API")
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<? extends CommonResponse> deleteProduct(@PathVariable UUID productId) {
+
+        productService.deleteProduct(productId);
+
+        return ResponseEntity.status(DELETE_PRODUCT_SUCCESS.getHttpStatus())
+                .body(success(DELETE_PRODUCT_SUCCESS.getMessage()));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.yongyonglee.vendor.domain.product.controller;
 
 import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.CREATE_PRODUCT_SUCCESS;
+import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.GET_PRODUCT_SUCCESS;
 import static com.yongyonglee.vendor.global.response.SuccessResponse.success;
 
 import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
@@ -8,8 +9,11 @@ import com.yongyonglee.vendor.domain.product.service.ProductService;
 import com.yongyonglee.vendor.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +33,13 @@ public class ProductController {
     public ResponseEntity<? extends CommonResponse> createProduct(@RequestBody CreateProductRequestDto requestDto) {
         return ResponseEntity.status(CREATE_PRODUCT_SUCCESS.getHttpStatus())
                 .body(success(CREATE_PRODUCT_SUCCESS.getMessage(), productService.createProduct(requestDto)));
+    }
+
+    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGE, MASTER) 추가
+    @Operation(summary = "상품 단건 조회", description = "상품을 단건 조회할 때 사용하는 API")
+    @GetMapping("/{productId}")
+    public ResponseEntity<? extends CommonResponse> getProduct(@PathVariable UUID productId) {
+        return ResponseEntity.status(GET_PRODUCT_SUCCESS.getHttpStatus())
+                .body(success(GET_PRODUCT_SUCCESS.getMessage(), productService.getProduct(productId)));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
@@ -1,0 +1,33 @@
+package com.yongyonglee.vendor.domain.product.controller;
+
+import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.CREATE_PRODUCT_SUCCESS;
+import static com.yongyonglee.vendor.global.response.SuccessResponse.success;
+
+import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
+import com.yongyonglee.vendor.domain.product.service.ProductService;
+import com.yongyonglee.vendor.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
+@Tag(name = "Product-Controller", description = "/api/v1/products")
+public class ProductController {
+
+    private final ProductService productService;
+
+    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGE, MASTER) 추가
+    @Operation(summary = "상품 등록", description = "상품을 등록할 때 사용하는 API")
+    @PostMapping("")
+    public ResponseEntity<? extends CommonResponse> createProduct(@RequestBody CreateProductRequestDto requestDto) {
+        return ResponseEntity.status(CREATE_PRODUCT_SUCCESS.getHttpStatus())
+                .body(success(CREATE_PRODUCT_SUCCESS.getMessage(), productService.createProduct(requestDto)));
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
@@ -11,12 +11,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,5 +45,18 @@ public class ProductController {
     public ResponseEntity<? extends CommonResponse> getProduct(@PathVariable UUID productId) {
         return ResponseEntity.status(GET_PRODUCT_SUCCESS.getHttpStatus())
                 .body(success(GET_PRODUCT_SUCCESS.getMessage(), productService.getProduct(productId)));
+    }
+
+    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGE, MASTER) 추가
+    @Operation(summary = "상품 검색", description = "상품을 검색할 때 사용하는 API")
+    @GetMapping("")
+    public ResponseEntity<? extends CommonResponse> searchProducts(
+            @RequestParam(required = false) UUID vendorId,
+            @RequestParam(required = false) UUID hubId,
+            @RequestParam(required = false) String productName,
+            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.status(GET_PRODUCT_SUCCESS.getHttpStatus())
+                .body(success(GET_PRODUCT_SUCCESS.getMessage(), productService.searchProducts(vendorId, hubId, productName, pageable)));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/controller/ProductController.java
@@ -2,9 +2,11 @@ package com.yongyonglee.vendor.domain.product.controller;
 
 import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.CREATE_PRODUCT_SUCCESS;
 import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.GET_PRODUCT_SUCCESS;
+import static com.yongyonglee.vendor.domain.product.message.SuccessMessage.UPDATE_PRODUCT_SUCCESS;
 import static com.yongyonglee.vendor.global.response.SuccessResponse.success;
 
 import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
+import com.yongyonglee.vendor.domain.product.dto.request.UpdateProductQuantityRequestDto;
 import com.yongyonglee.vendor.domain.product.service.ProductService;
 import com.yongyonglee.vendor.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,5 +61,16 @@ public class ProductController {
 
         return ResponseEntity.status(GET_PRODUCT_SUCCESS.getHttpStatus())
                 .body(success(GET_PRODUCT_SUCCESS.getMessage(), productService.searchProducts(vendorId, hubId, productName, pageable)));
+    }
+
+    // TODO: 사용자 인증 및 인가(VENDOR_MANAGER, HUB_MANAGE, MASTER) 추가
+    @Operation(summary = "상품 수량 변경", description = "상품 수량을 변경할 때 사용하는 API")
+    @PatchMapping("/{productId}/quantity")
+    public ResponseEntity<? extends CommonResponse> updateProductQuantity(
+            @PathVariable UUID productId,
+            @RequestBody UpdateProductQuantityRequestDto requestDto) {
+
+        return ResponseEntity.status(UPDATE_PRODUCT_SUCCESS.getHttpStatus())
+                .body(success(UPDATE_PRODUCT_SUCCESS.getMessage(), productService.updateProductQuantity(productId, requestDto)));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/dto/request/CreateProductRequestDto.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/dto/request/CreateProductRequestDto.java
@@ -1,0 +1,33 @@
+package com.yongyonglee.vendor.domain.product.dto.request;
+
+import com.yongyonglee.vendor.domain.product.model.Product;
+import com.yongyonglee.vendor.domain.vendor.model.Vendor;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record CreateProductRequestDto(
+
+        @NotBlank(message = "상품명은 필수 입력값입니다.")
+        @Size(max = 100, message = "상품명는 100자를 초과할 수 없습니다.")
+        String productName,
+
+        @NotBlank(message = "업체의 Id는 필수 입력값입니다.")
+        UUID vendorId,
+
+        @NotNull(message = "수량은 필수 입력값입니다.")
+        @Min(value = 1, message = "수량은 최소 1이상 설정해주세요.")
+        Integer quantity
+){
+
+        public Product toEntity(Vendor vendor) {
+                return Product.builder()
+                        .vendor(vendor)
+                        .hubId(vendor.getHubId())
+                        .productName(productName)
+                        .quantity(quantity)
+                        .build();
+        }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/dto/request/UpdateProductQuantityRequestDto.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/dto/request/UpdateProductQuantityRequestDto.java
@@ -1,0 +1,11 @@
+package com.yongyonglee.vendor.domain.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record UpdateProductQuantityRequestDto(
+
+        @Min(value = 1, message = "수량은 최소 1이상 설정해주세요.")
+        Integer quantity
+) {
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/dto/response/ProductResponseDto.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/dto/response/ProductResponseDto.java
@@ -1,0 +1,26 @@
+package com.yongyonglee.vendor.domain.product.dto.response;
+
+import com.yongyonglee.vendor.domain.product.model.Product;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ProductResponseDto(
+        UUID productId,
+        UUID vendorId,
+        UUID hubId,
+        String productName,
+        Integer quantity
+) {
+
+    public static ProductResponseDto from(Product product) {
+        return ProductResponseDto.builder()
+                .productId(product.getId())
+                .vendorId(product.getVendor().getId())
+                .hubId(product.getHubId())
+                .productName(product.getProductName())
+                .quantity(product.getQuantity())
+                .build();
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/exception/ProductException.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/exception/ProductException.java
@@ -1,0 +1,22 @@
+package com.yongyonglee.vendor.domain.product.exception;
+
+import com.yongyonglee.vendor.domain.product.message.ExceptionMessage;
+import org.springframework.http.HttpStatus;
+
+public class ProductException extends RuntimeException {
+
+    private final ExceptionMessage exceptionMessage;
+
+    public ProductException(final ExceptionMessage exceptionMessage) {
+        super("[Product Exception]" + exceptionMessage.getMessage());
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return exceptionMessage.getHttpStatus();
+    }
+
+    public String getMessage() {
+        return exceptionMessage.getMessage();
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/message/ExceptionMessage.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/message/ExceptionMessage.java
@@ -1,0 +1,16 @@
+package com.yongyonglee.vendor.domain.product.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionMessage {
+
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품를 찾을 수 없습니다."),
+    PRODUCT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "상품에 대한 접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/message/SuccessMessage.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/message/SuccessMessage.java
@@ -1,0 +1,20 @@
+package com.yongyonglee.vendor.domain.product.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessMessage {
+
+    CREATE_PRODUCT_SUCCESS(HttpStatus.CREATED, "상품 등록을 성공했습니다"),
+    GET_PRODUCT_SUCCESS(HttpStatus.OK, "상품 조회를 성공했습니다"),
+    SEARCH_PRODUCT_SUCCESS(HttpStatus.OK, "상품 검색을 성공했습니다"),
+    UPDATE_PRODUCT_SUCCESS(HttpStatus.OK, "상품 수정을 성공했습니다"),
+    DELETE_PRODUCT_SUCCESS(HttpStatus.OK, "상품 삭제를 성공했습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/model/Product.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/model/Product.java
@@ -52,4 +52,8 @@ public class Product extends TimeBase {
     public void updateQuantity(Integer quantity) {
         this.quantity = quantity;
     }
+
+    public void deleteProduct(String userName) {
+        super.setDeleted(userName);
+    }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/model/Product.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/model/Product.java
@@ -1,5 +1,6 @@
 package com.yongyonglee.vendor.domain.product.model;
 
+import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
 import com.yongyonglee.vendor.domain.vendor.model.Vendor;
 import com.yongyonglee.vendor.global.entity.TimeBase;
 import jakarta.persistence.Column;
@@ -13,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,4 +41,11 @@ public class Product extends TimeBase {
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
 
+    @Builder(access = AccessLevel.PUBLIC)
+    public Product(Vendor vendor, UUID hubId, String productName, Integer quantity) {
+        this.vendor = vendor;
+        this.hubId = hubId;
+        this.productName = productName;
+        this.quantity = quantity;
+    }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/model/Product.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/model/Product.java
@@ -48,4 +48,8 @@ public class Product extends TimeBase {
         this.productName = productName;
         this.quantity = quantity;
     }
+
+    public void updateQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/repository/ProductRepository.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/repository/ProductRepository.java
@@ -1,13 +1,17 @@
 package com.yongyonglee.vendor.domain.product.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.yongyonglee.vendor.domain.product.model.Product;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductRepository extends JpaRepository<Product, UUID> {
+public interface ProductRepository extends JpaRepository<Product, UUID>, QuerydslPredicateExecutor<Product> {
 
     Optional<Product> findByIdAndIsDeletedFalse(UUID productId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/repository/ProductRepository.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package com.yongyonglee.vendor.domain.product.repository;
 
 import com.yongyonglee.vendor.domain.product.model.Product;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, UUID> {
 
+    Optional<Product> findByIdAndIsDeletedFalse(UUID productId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/repository/ProductRepository.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/repository/ProductRepository.java
@@ -1,0 +1,11 @@
+package com.yongyonglee.vendor.domain.product.repository;
+
+import com.yongyonglee.vendor.domain.product.model.Product;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, UUID> {
+
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
@@ -1,0 +1,9 @@
+package com.yongyonglee.vendor.domain.product.service;
+
+import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
+import com.yongyonglee.vendor.domain.product.dto.response.ProductResponseDto;
+
+public interface ProductService {
+
+    ProductResponseDto createProduct(CreateProductRequestDto requestDto);
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
@@ -4,12 +4,16 @@ import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto
 import com.yongyonglee.vendor.domain.product.dto.response.ProductResponseDto;
 import com.yongyonglee.vendor.domain.product.model.Product;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ProductService {
 
     ProductResponseDto createProduct(CreateProductRequestDto requestDto);
 
     ProductResponseDto getProduct(UUID productId);
+
+    Page<ProductResponseDto> searchProducts(UUID vendorId, UUID hubId, String productName, Pageable pageable);
 
     Product findById(UUID productId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
@@ -2,8 +2,14 @@ package com.yongyonglee.vendor.domain.product.service;
 
 import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
 import com.yongyonglee.vendor.domain.product.dto.response.ProductResponseDto;
+import com.yongyonglee.vendor.domain.product.model.Product;
+import java.util.UUID;
 
 public interface ProductService {
 
     ProductResponseDto createProduct(CreateProductRequestDto requestDto);
+
+    ProductResponseDto getProduct(UUID productId);
+
+    Product findById(UUID productId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
@@ -18,5 +18,7 @@ public interface ProductService {
 
     ProductResponseDto updateProductQuantity(UUID productId, UpdateProductQuantityRequestDto requestDto);
 
+    void deleteProduct(UUID productId);
+
     Product findById(UUID productId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.yongyonglee.vendor.domain.product.service;
 
 import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
+import com.yongyonglee.vendor.domain.product.dto.request.UpdateProductQuantityRequestDto;
 import com.yongyonglee.vendor.domain.product.dto.response.ProductResponseDto;
 import com.yongyonglee.vendor.domain.product.model.Product;
 import java.util.UUID;
@@ -14,6 +15,8 @@ public interface ProductService {
     ProductResponseDto getProduct(UUID productId);
 
     Page<ProductResponseDto> searchProducts(UUID vendorId, UUID hubId, String productName, Pageable pageable);
+
+    ProductResponseDto updateProductQuantity(UUID productId, UpdateProductQuantityRequestDto requestDto);
 
     Product findById(UUID productId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductServiceImpl.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductServiceImpl.java
@@ -86,6 +86,14 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
+    public void deleteProduct(UUID productId) {
+
+        Product product = findById(productId);
+
+        product.deleteProduct("userName");
+    }
+
+    @Override
     public Product findById(UUID productId) {
 
         return productRepository.findByIdAndIsDeletedFalse(productId)

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductServiceImpl.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductServiceImpl.java
@@ -1,0 +1,29 @@
+package com.yongyonglee.vendor.domain.product.service;
+
+import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
+import com.yongyonglee.vendor.domain.product.dto.response.ProductResponseDto;
+import com.yongyonglee.vendor.domain.product.model.Product;
+import com.yongyonglee.vendor.domain.product.repository.ProductRepository;
+import com.yongyonglee.vendor.domain.vendor.model.Vendor;
+import com.yongyonglee.vendor.domain.vendor.service.VendorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductServiceImpl implements ProductService{
+
+    private final ProductRepository productRepository;
+    private final VendorService vendorService;
+
+    @Override
+    public ProductResponseDto createProduct(CreateProductRequestDto requestDto) {
+
+        Vendor vendor = vendorService.findById(requestDto.vendorId());
+
+        Product product = requestDto.toEntity(vendor);
+        productRepository.save(product);
+
+        return ProductResponseDto.from(product);
+    }
+}

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductServiceImpl.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/product/service/ProductServiceImpl.java
@@ -2,10 +2,13 @@ package com.yongyonglee.vendor.domain.product.service;
 
 import com.yongyonglee.vendor.domain.product.dto.request.CreateProductRequestDto;
 import com.yongyonglee.vendor.domain.product.dto.response.ProductResponseDto;
+import com.yongyonglee.vendor.domain.product.exception.ProductException;
+import com.yongyonglee.vendor.domain.product.message.ExceptionMessage;
 import com.yongyonglee.vendor.domain.product.model.Product;
 import com.yongyonglee.vendor.domain.product.repository.ProductRepository;
 import com.yongyonglee.vendor.domain.vendor.model.Vendor;
 import com.yongyonglee.vendor.domain.vendor.service.VendorService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -25,5 +28,20 @@ public class ProductServiceImpl implements ProductService{
         productRepository.save(product);
 
         return ProductResponseDto.from(product);
+    }
+
+    @Override
+    public ProductResponseDto getProduct(UUID productId) {
+
+        Product product = findById(productId);
+
+        return ProductResponseDto.from(product);
+    }
+
+    @Override
+    public Product findById(UUID productId) {
+
+        return productRepository.findByIdAndIsDeletedFalse(productId)
+                .orElseThrow(() -> new ProductException(ExceptionMessage.PRODUCT_NOT_FOUND));
     }
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorService.java
@@ -3,6 +3,7 @@ package com.yongyonglee.vendor.domain.vendor.service;
 import com.yongyonglee.vendor.domain.vendor.dto.request.CreateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.dto.request.UpdateVendorRequestDto;
 import com.yongyonglee.vendor.domain.vendor.dto.response.VendorResponseDto;
+import com.yongyonglee.vendor.domain.vendor.model.Vendor;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,4 +19,6 @@ public interface VendorService {
     VendorResponseDto updateVendor(UUID vendorId, UpdateVendorRequestDto requestDto);
 
     void deleteVendor(UUID vendorId);
+
+    Vendor findById(UUID vendorId);
 }

--- a/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/domain/vendor/service/VendorServiceImpl.java
@@ -105,6 +105,7 @@ public class VendorServiceImpl implements VendorService {
 //        productService.deleteRelatedVendorId(vendorId);
     }
 
+    @Override
     public Vendor findById(UUID vendorId) {
         return vendorRepository.findByIdAndIsDeletedFalse(vendorId)
                 .orElseThrow(() -> new VendorException(ExceptionMessage.VENDOR_NOT_FOUND));

--- a/vendor/src/main/java/com/yongyonglee/vendor/global/config/SwaggerConfig.java
+++ b/vendor/src/main/java/com/yongyonglee/vendor/global/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.yongyonglee.vendor.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("VENDOR-SERVICE API")
+                .description("TEAM 용용이 vendor 서비스의 vendor, product 관련 swagger 페이지입니다.")
+                .version("1.0.0");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#29 

## 📝작업 내용

- product 도메인의 crud api 모두 구현
- 수정은 product의 수량(quantity)만 수정가능하도록 구현했습니다.
- 상품 등록시에, vendorId랑 hubId를 따로 입력받도록 되어있었는데, 이 부분은 vendorId로 vendor 조회하면 hubId를 알 수 있기 때문에 hubId는 받지 않는 것으로 하여 구현했습니다.