### PR TITLE
Refactor/#34 hub caching

### DIFF
--- a/hub/src/main/java/com/yongyonglee/hub/HubApplication.java
+++ b/hub/src/main/java/com/yongyonglee/hub/HubApplication.java
@@ -2,8 +2,11 @@ package com.yongyonglee.hub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 public class HubApplication {
 
 	public static void main(String[] args) {

--- a/hub/src/main/java/com/yongyonglee/hub/domain/hub/dto/response/CreateHubResponseDto.java
+++ b/hub/src/main/java/com/yongyonglee/hub/domain/hub/dto/response/CreateHubResponseDto.java
@@ -1,6 +1,7 @@
 package com.yongyonglee.hub.domain.hub.dto.response;
 
 import com.yongyonglee.hub.domain.hub.model.Hub;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -14,7 +15,7 @@ public record CreateHubResponseDto(
         Double latitude,
         Double longitude,
         LocalDateTime createdAt
-) {
+) implements Serializable {
 
     public static CreateHubResponseDto from(Hub hub) {
         return CreateHubResponseDto.builder()

--- a/hub/src/main/java/com/yongyonglee/hub/domain/hub/dto/response/HubResponseDto.java
+++ b/hub/src/main/java/com/yongyonglee/hub/domain/hub/dto/response/HubResponseDto.java
@@ -1,6 +1,7 @@
 package com.yongyonglee.hub.domain.hub.dto.response;
 
 import com.yongyonglee.hub.domain.hub.model.Hub;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -14,7 +15,7 @@ public record HubResponseDto (
         Double latitude,
         Double longitude,
         LocalDateTime createdAt
-) {
+) implements Serializable {
 
     public static HubResponseDto from(Hub hub) {
         return HubResponseDto.builder()

--- a/hub/src/main/java/com/yongyonglee/hub/global/config/CacheConfig.java
+++ b/hub/src/main/java/com/yongyonglee/hub/global/config/CacheConfig.java
@@ -1,0 +1,35 @@
+package com.yongyonglee.hub.global.config;
+
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(2))
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.java())
+                );
+
+        return RedisCacheManager
+                .builder(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -17,6 +17,12 @@ spring:
         show_sql: true
         database-platform: org.hibernate.dialect.PostgreSQLDialect
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: {REDIS_PASSWORD}
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## #️⃣연관된 이슈
#34 

## 📝작업 내용

- hub 서비스에 캐싱 적용했습니다.
  - hub 단건 조회시, (hubCache:{hubId}) 전체 조회시 (hubAllCache) 캐싱 하도록 했습니다
  - hub 등록시 hubAllCache은 삭제되도록 했습니다.
  - hub 수정시 hubAllCache는 삭제되고, hubCache:{hubId}는 수정됩니다.
  - search에 대한 캐싱은 적용하지 않았습니다.

- application.yml 파일에 <img src = "https://img.shields.io/badge/Redis-FF4438?&logo=redis&logoColor=white"> 설정이 추가되었습니다. 개인 로컬 환경에 맞게 수정해주시면 됩니다.


- Page 객체를 응답 받을 때 발생하는 워닝이 있었습니다. `@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)` 어노테이션을 통해 직렬화 방식을 명시하여 해결했습니다.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 인메모리 2-4 강의