### PR TITLE
Feat: (#38) 회원가입 기능 구현

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -31,7 +31,10 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -9,8 +9,8 @@ spring:
   cloud:
     gateway:
       routes:  # Spring Cloud Gateway의 라우팅 설정
-        - id: auth-service     # 19092
-          uri: lb://auth-service
+        - id: user-service
+          uri: lb://user-service
           predicates:
             - Path=/api/v1/auth/**
         - id: user-service     # 19093

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -28,10 +28,11 @@ ext {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/user/docs/client/auth-api.http
+++ b/user/docs/client/auth-api.http
@@ -1,0 +1,12 @@
+POST http://localhost:19091/api/v1/auth/sign-up
+Content-Type: application/json
+
+{
+  "username": "홍길동",
+  "nickname": "홍",
+  "email" : "hong@gmail.com",
+  "password": "password",
+  "hubId": "945c2bcb-1495-4294-80ad-f5818f10f336",
+  "slackId": "hong",
+  "role" : "MANAGER"
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/controller/AuthController.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.yongyonglee.user.domain.user.controller;
+
+import com.yongyonglee.user.domain.user.controller.dto.SignUpRequest;
+import com.yongyonglee.user.domain.user.service.AuthService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+  private final AuthService authService;
+
+  @PostMapping("/sign-up")
+  ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest){
+    Long userId = authService.createUser(signUpRequest);
+    URI userUri = UriComponentsBuilder.fromUriString("/user/{userId}")
+        .buildAndExpand(userId)
+        .toUri();
+    return ResponseEntity.created(userUri).build();
+  }
+
+
+
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/controller/UserController.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/controller/UserController.java
@@ -1,0 +1,9 @@
+package com.yongyonglee.user.domain.user.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/controller/dto/SignUpRequest.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/controller/dto/SignUpRequest.java
@@ -1,0 +1,21 @@
+package com.yongyonglee.user.domain.user.controller.dto;
+
+import com.yongyonglee.user.domain.user.entity.Role;
+import com.yongyonglee.user.domain.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class SignUpRequest {
+  private String username;
+  private String nickname;
+  private String email;
+  private String password;
+  private String hubId;
+  private String slackId;
+  private Role role;
+
+  public User toEntity(String password) {
+    return User.of(username,nickname,email,password,hubId,slackId,role);
+  }
+
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/entity/Role.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/entity/Role.java
@@ -1,0 +1,11 @@
+package com.yongyonglee.user.domain.user.entity;
+
+public enum Role {
+  MASTER("관리자"), MANAGER("허브 관리자"), HUB_DELIVER("허브 이동 담당자"), VENDOR_DELIVER("업체 배송 담당자"), VENDOR_MANAGER("업체 관리자");
+
+  private String description;
+
+  Role(String description) {
+    this.description = description;
+  }
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/entity/User.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/entity/User.java
@@ -10,11 +10,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "p_user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class User {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,9 +44,19 @@ public class User {
   @Column(nullable = false)
   private UUID hubId;  // 허브 ID, Foreign Key
 
+  private User(String username, String nickname, String email, String password,String hubId,String slackId, Role role) {
+    this.username = username;
+    this.nickname = nickname;
+    this.email = email;
+    this.password = password;
+    this.slackId = slackId;
+    this.role = role;
+    this.hubId = UUID.fromString(hubId);
+  }
 
 
-
-
+  public static User of(String username, String nickname, String email, String password, String hubId, String slackId ,Role role) {
+    return new User(username, nickname, email, password, hubId, slackId,role);
+  }
 
 }

--- a/user/src/main/java/com/yongyonglee/user/domain/user/entity/User.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/entity/User.java
@@ -1,0 +1,50 @@
+package com.yongyonglee.user.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 100)
+  private String username;
+
+  @Column(length = 100)
+  private String nickname;
+
+  @Column(nullable = false, unique = true, length = 255)
+  private String email;
+
+  @Column(nullable = false, length = 255)
+  private String password;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role;
+
+  @Column(length = 255)
+  private String slackId;
+
+  @Column(nullable = false)
+  private UUID hubId;  // 허브 ID, Foreign Key
+
+
+
+
+
+
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/repository/UserRepository.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/repository/UserRepository.java
@@ -7,4 +7,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  boolean existsByNickname(String nickname);
+
+  boolean existsByEmail(String email);
+
 }

--- a/user/src/main/java/com/yongyonglee/user/domain/user/repository/UserRepository.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.yongyonglee.user.domain.user.repository;
+
+import com.yongyonglee.user.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/service/AuthService.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/service/AuthService.java
@@ -1,0 +1,50 @@
+package com.yongyonglee.user.domain.user.service;
+
+import com.yongyonglee.user.domain.user.controller.dto.SignUpRequest;
+import com.yongyonglee.user.domain.user.entity.User;
+import com.yongyonglee.user.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+  private final PasswordEncoder passwordEncoder;
+  private final UserRepository userRepository;
+
+  private static final String DUPLICATED_EMAIL_ERROR_MESSAGE = "이미 존재하는 이메일입니다.";
+  private static final String DUPLICATED_NICKNAME_ERROR_MESSAGE = "이미 존재하는 닉네임입니다.";
+  public static final String INVALID_AUTHENTICATION_ERROR_MESSAGE = "사용자 정보가 올바르지 않습니다.";
+
+
+  public Long createUser(SignUpRequest signUpRequest) {
+    validate(signUpRequest);
+    String password = passwordEncoder.encode(signUpRequest.getPassword());
+    User user = signUpRequest.toEntity(password);
+    User savedUser = userRepository.save(user);
+    return savedUser.getId();
+  }
+  private void validate(SignUpRequest signUpRequest) {
+    validateDuplicatedEmail(signUpRequest.getEmail());
+    validateDuplicatedNickname(signUpRequest.getNickname());
+  }
+
+  private void validateDuplicatedNickname(String nickname) {
+    boolean exits = userRepository.existsByNickname(nickname);
+    if(exits){
+      throw new IllegalArgumentException(DUPLICATED_NICKNAME_ERROR_MESSAGE);
+    }
+  }
+
+  private void validateDuplicatedEmail(String email) {
+    boolean exits = userRepository.existsByEmail(email);
+    if(exits){
+      throw new IllegalArgumentException(DUPLICATED_EMAIL_ERROR_MESSAGE);
+    }
+  }
+
+
+
+
+}

--- a/user/src/main/java/com/yongyonglee/user/domain/user/service/UserService.java
+++ b/user/src/main/java/com/yongyonglee/user/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.yongyonglee.user.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+}

--- a/user/src/main/java/com/yongyonglee/user/global/security/PasswordEncoderConfig.java
+++ b/user/src/main/java/com/yongyonglee/user/global/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.yongyonglee.user.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+}

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -2,10 +2,25 @@ spring:
   application:
     name: user-service
 
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: pw
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
 eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
 
 server:
   port: 19093


### PR DESCRIPTION
## #️⃣연관된 이슈

close #38 

## 📝작업 내용
- gateway설정 변경 : /auth 관련 api user-service로 호출
- 회원가입 성공시 201 status 및 Uri 반환
- passowrdEncoder bean 등록
- AuthService 내 유저 생성 기능 구현
 - 비밀번호 암호화 설정
 - 이메일 , 닉네임 중복검사
- SignUpRequest , toEntity 기능 구현
 - 정적팩토리 메서드를 통한  유저 객체 생성
- auth-api.http 를 통한 회원가입 테스트
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
